### PR TITLE
feat: use byteorder to read little endian number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,7 @@ dependencies = [
 name = "rustaria"
 version = "0.1.0"
 dependencies = [
+ "byteorder",
  "num_enum",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+byteorder = "1.4.3"
 num_enum = "0.7.0"


### PR DESCRIPTION
Message logs
```
kind = ConnectRequest, length = 15, payload = "Terraria279"
kind = PlayerInfo, length = 40, payload = [0, 0, 0, 5, 106, 101, 115, 115, 101, 0, 0, 0, 0, 215, 90, 55, 255, 125, 90, 105, 90, 75, 175, 165, 140, 160, 180, 215, 255, 230, 175, 160, 105, 60, 0, 16, 0]
kind = ClientUUID, length = 40, payload = "$640627d0-34c6-48c0-8297-7668a2c1f83c"
```